### PR TITLE
Update Go test matrix to add Go v1.18

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,18 +13,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.16', '1.17']
+        go: ['1.17', '1.18']
     steps:
       - name: setup
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{matrix.go}}
 
       - name: checkout
-        uses: actions/checkout@v2
-
-      - name: tools
-        run: go get golang.org/x/lint/golint
+        uses: actions/checkout@v3
 
       - name: test
         run: make

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: all
-all: test vet lint fmt
+all: test vet fmt
 
 .PHONY: test
 test:
@@ -8,10 +8,6 @@ test:
 .PHONY: vet
 vet:
 	@go vet -all .
-
-.PHONY: lint
-lint:
-	@golint -set_exit_status ./...
 
 .PHONY: fmt
 fmt:

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/dghubble/ipnets
 
-go 1.16
+go 1.17


### PR DESCRIPTION
* Update checkout and setup-go Github Actions
* Remove golint since its deprecated
* Drop Go v1.16